### PR TITLE
fix: update package deps for python >3.10

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -75,7 +75,7 @@ table-meta = ">=0.1.5,<0.2.0"
 
 [[package]]
 name = "parsimonious"
-version = "0.8.1"
+version = "0.1.0"
 description = "(Soon to be) the fastest pure-Python PEG parser I could muster"
 category = "main"
 optional = false
@@ -101,7 +101,7 @@ optional = false
 python-versions = ">=3.6,<4.0"
 
 [package.dependencies]
-parsimonious = ">=0.8.1,<0.9.0"
+parsimonious = ">0.9.0"
 
 [[package]]
 name = "pydantic"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dbml-builder"
-version = "0.4.1"
+version = "0.4.2"
 description = "Builds usable models from DBML"
 authors = ["Five Grant <five@jataware.com>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,8 @@ keywords = ["dbml", "sql"]
 click = "^8.1"
 python = "^3.10"
 pydantic = "^1.10.2"
-pydbml = "^1.0.3"
-omymodels = "^0.12.1"
+pydbml = "^1.0.9"
+omymodels = "^0.14.0"
 SQLAlchemy = "^1.4.41"
 funcy = "^1.17"
 


### PR DESCRIPTION
One of the deps (`parsimonious` namely) relies on `inspect.getargspec` which is removed in python >3.10.
Updating `dbml-builder` deps for `pydbml = ^1.0.9` and `omymodels = ^0.14.0` fixes this problem.